### PR TITLE
Small improvements

### DIFF
--- a/app/client/src/app/pages/Generator.js
+++ b/app/client/src/app/pages/Generator.js
@@ -69,9 +69,6 @@ type Props = {
 function Generator({ location }: Props) {
   return (
     <Layout>
-      <Header>
-        <Logo />
-      </Header>
       <SideNav />
       <Content>
         <Form location={location} />

--- a/app/client/src/app/pages/Generator.js
+++ b/app/client/src/app/pages/Generator.js
@@ -4,6 +4,7 @@
 
 import React from 'react'
 import Loadable from 'react-loadable'
+import { ToastContainer } from 'react-toastify'
 import styled from 'styled-components'
 import Form from '../../features/form/components'
 import { SideNav, Progress } from '../../features/progress/components'
@@ -69,6 +70,7 @@ type Props = {
 function Generator({ location }: Props) {
   return (
     <Layout>
+      <ToastContainer />
       <SideNav />
       <Content>
         <Form location={location} />

--- a/app/client/src/app/store.js
+++ b/app/client/src/app/store.js
@@ -21,7 +21,25 @@ if (process.env.NODE_ENV === 'development') {
 
 const enhancer = composeWithDevTools(
   applyMiddleware(...middleware),
-  persistState(['form', 'progress'], { key: 'resumake' })
+  persistState(
+    ['form', 'progress', 'tdi'],
+    {
+      key: 'resumake',
+      slicer: (paths) => (state) => {
+        // TODO: too risky and untested! Just a quick (and cool) solution not to persist fellowData.
+        const subset = {}
+        paths.forEach((path) => {
+          if (path !== 'tdi') {
+            subset[path] = state[path]
+          } else {
+            const { fellowData, ...tdiStateRest } = state[path]
+            subset[path] = tdiStateRest
+          }
+        })
+        return subset
+      }
+    }
+  )
 )
 
 const store = createStore(reducer, enhancer)

--- a/app/client/src/common/theme.js
+++ b/app/client/src/common/theme.js
@@ -13,7 +13,7 @@ const colors = {
 }
 
 const sizes = {
-  header: '10vh',
+  header: '0vh',
   sideNav: '225px',
   footer: '65px'
 }

--- a/app/client/src/features/form/components/Form.js
+++ b/app/client/src/features/form/components/Form.js
@@ -20,7 +20,7 @@ import Preview from '../../preview/components'
 import { ScrollToTop } from '../../../common/components'
 import { generateResume } from '../../preview/actions'
 import { setProgress } from '../../progress/actions'
-import { fetchIfNeededAndResetFormToSavedState } from '../../tdi/actions'
+import { fetchFellowDataAndResetFormToIt } from '../../tdi/actions'
 import { mayResetFormToFellowData } from '../../tdi/selectors'
 import { colors } from '../../../common/theme'
 import type { FormValues } from '../types'
@@ -46,7 +46,9 @@ type Props = {
   handleSubmit: *,
   setProgress: (sections: Array<Section>, curr: Section) => void,
   generateResume: (payload: FormValues) => Promise<void>,
-  mayResetFormToFellowData: *
+  formValues: FormValues,
+  mayResetFormToFellowData: *,
+  fetchFellowDataAndResetFormToIt: *
 }
 
 class Form extends Component<Props> {
@@ -63,10 +65,14 @@ class Form extends Component<Props> {
   }
 
   componentDidMount() {
-    const { mayResetFormToFellowData, fetchIfNeededAndResetFormToSavedState } = this.props
+    const { mayResetFormToFellowData, fetchFellowDataAndResetFormToIt } = this.props
     if (mayResetFormToFellowData) {
       // mayResetFormToFellowData implies that "IfNeeded" part is satisfied.
-      fetchIfNeededAndResetFormToSavedState()
+      fetchFellowDataAndResetFormToIt()
+    } else {
+      // In any case, sync the preview.
+      const { generateResume, formValues, sections } = this.props
+      generateResume({ ...formValues, sections })
     }
   }
 
@@ -128,6 +134,7 @@ class Form extends Component<Props> {
 
 function mapState(state: State) {
   return {
+    formValues: state.form.resume.values,
     sections: state.progress.sections,
     progress: state.progress.progress,
     initialValues: state.tdi.fellowData,
@@ -138,7 +145,7 @@ function mapState(state: State) {
 const mapActions = {
   generateResume,
   setProgress,
-  fetchIfNeededAndResetFormToSavedState
+  fetchFellowDataAndResetFormToIt
 }
 
 const ReduxForm = reduxForm({

--- a/app/client/src/features/progress/components/SideNav.js
+++ b/app/client/src/features/progress/components/SideNav.js
@@ -12,7 +12,7 @@ import styled from 'styled-components'
 import SortableList from './SortableList'
 import { PrimaryButton } from '../../../common/components'
 import { setSectionOrder, setProgress } from '../actions'
-import { fetchIfNeededAndResetFormToSavedState, saveFellowData, publishPDF } from '../../tdi/actions'
+import { fetchFellowDataAndResetFormToIt, saveFellowData, publishPDF } from '../../tdi/actions'
 import { previewMatchesFormData } from '../../tdi/selectors'
 import { sizes, colors } from '../../../common/theme'
 import type { Section } from '../../../common/types'
@@ -125,7 +125,7 @@ type Props = {
     currSection: Section
   ) => void,
   setProgress: (newSectionOrder: Array<Section>, currSection: Section) => void,
-  fetchIfNeededAndResetFormToSavedState: *,
+  fetchFellowDataAndResetFormToIt: *,
   saveFellowData: *,
   disablePublish: boolean
 }
@@ -156,8 +156,8 @@ class SideNav extends Component<Props> {
   }
 
   handleResetFormToSavedStateClick = () => {
-    const { fetchIfNeededAndResetFormToSavedState } = this.props
-    fetchIfNeededAndResetFormToSavedState()
+    const { fetchFellowDataAndResetFormToIt } = this.props
+    fetchFellowDataAndResetFormToIt()
   }
 
   handleUploadPdfClick = () => {
@@ -264,7 +264,7 @@ function mapState(state: State) {
 const mapActions = {
   setSectionOrder,
   setProgress,
-  fetchIfNeededAndResetFormToSavedState,
+  fetchFellowDataAndResetFormToIt,
   saveFellowData,
   publishPDF,
   uploadFileAndGenerateResume

--- a/app/client/src/features/progress/components/SideNav.js
+++ b/app/client/src/features/progress/components/SideNav.js
@@ -183,7 +183,7 @@ class SideNav extends Component<Props> {
 
     return (
       <Aside>
-        <div style={{overflow: "auto", "min-height": "100%"}}>
+        <div style={{ overflow: "auto", "minHeight": "100%" }}>
           <Nav>
             <SortableList
               useDragHandle
@@ -225,11 +225,11 @@ class SideNav extends Component<Props> {
             <Heading>
               Local versions
             </Heading>
-            { previewUpdated ?
+            {previewUpdated ?
               <RButtonLink href={jsonURL} download="resume.json">
                 Download JSON
               </RButtonLink>
-            :
+              :
               <RButton disabled data-tip="Update preview to download JSON.">
                 Download JSON
               </RButton>
@@ -240,7 +240,7 @@ class SideNav extends Component<Props> {
             <input
               id="import-json"
               type="file"
-              style={{display: "none"}}
+              style={{ display: "none" }}
               onChange={this.handleFileUpload}
             />
             <ReactTooltip type="info" effect="solid" place="right" />

--- a/app/client/src/features/tdi/actions.js
+++ b/app/client/src/features/tdi/actions.js
@@ -25,9 +25,9 @@ function storeFellowKeyUrlsafe(fellowKeyUrlsafe: string): Action {
   }
 }
 
-function fetchFellowData(fellowKeyUrlsafe: ?string): AsyncAction {
+function fetchFellowData(): AsyncAction {
   return async (dispatch, getState) => {
-    const state = getState()
+    const { fellowKeyUrlsafe } = getState().tdi
     const { fetch } = window
     try {
       const fellowDataFetchBaseUrl = '/fellows/fetch_resume_json'
@@ -141,20 +141,13 @@ export function publishPDF(): AsyncAction {
 
 export function initializeApplication(fellowKeyUrlsafe: ?string, history: RouterHistory): AsyncAction {
   return async (dispatch, getState) => {
-    if (!fellowKeyUrlsafe) { // Not an admin. Just fetch the data.
+    if (!fellowKeyUrlsafe) { // Not an admin.
       history.push('/resumake/generator')
-      // I load fellow data only when the generator page is loaded. Otherwise, redux-form will pick
-      // up our data when initializing the form instead of the json which was just uploaded.
-      // (Yes, our integration with redux-form is tighter than the authors!)
       return
     }
     // In case of admins, we should purge the state first and start from scratch.
-    alert(`Application will reset and the resume data for the Fellow with id ${fellowKeyUrlsafe} will be loaded`)
+    alert(`Resetting the application and loading Fellow ${fellowKeyUrlsafe} data.`)
     dispatch(clearState())
-    await dispatch(fetchFellowData(fellowKeyUrlsafe))
-    if (hasNoFellowData(getState())) {
-      return
-    }
     dispatch(storeFellowKeyUrlsafe(fellowKeyUrlsafe))
     history.push('/resumake/generator')
   }

--- a/app/client/src/features/tdi/actions.js
+++ b/app/client/src/features/tdi/actions.js
@@ -9,6 +9,7 @@ import { reset } from 'redux-form'
 import type { Action, AsyncAction } from '../../app/types'
 import { FormValuesWithSectionOrder } from '../form/types'
 import { clearState } from '../../app/actions'
+import { generateResume } from '../../features/preview/actions'
 
 function updateSavedFellowData(fellowData): Action {
   return {
@@ -69,10 +70,14 @@ export function saveFellowData(resumeData: FormValuesWithSectionOrder): AsyncAct
   }
 }
 
-export function fetchIfNeededAndResetFormToSavedState(): AsyncAction {
+export function fetchFellowDataAndResetFormToIt(): AsyncAction {
+  // ResetForm_And_Preview, actually.
   return async (dispatch, getState) => {
-    await dispatch(fetchFellowData(getState().tdi.fellowKeyUrlsafe))
+    const { fellowKeyUrlsafe } = getState().tdi
+    await dispatch(fetchFellowData())
     dispatch(reset('resume'))
+    const { fellowData } = getState().tdi
+    await dispatch(generateResume(fellowData))
   }
 }
 

--- a/app/client/src/features/tdi/actions.js
+++ b/app/client/src/features/tdi/actions.js
@@ -141,14 +141,16 @@ export function publishPDF(): AsyncAction {
 
 export function initializeApplication(fellowKeyUrlsafe: ?string, history: RouterHistory): AsyncAction {
   return async (dispatch, getState) => {
-    if (!fellowKeyUrlsafe) { // Not an admin.
-      history.push('/resumake/generator')
-      return
+    if (fellowKeyUrlsafe) { // An admin.
+      // For admins, we should purge the state and start from scratch when starting to edit
+      // a new/different Fellow resume than the previous one.
+      const { fellowKeyUrlsafe: prevFellowKey } = getState().tdi
+      if (prevFellowKey !== fellowKeyUrlsafe) {
+        alert(`Resetting the application and loading Fellow ${fellowKeyUrlsafe} data.`)
+        dispatch(clearState())
+        dispatch(storeFellowKeyUrlsafe(fellowKeyUrlsafe))
+      }
     }
-    // In case of admins, we should purge the state first and start from scratch.
-    alert(`Resetting the application and loading Fellow ${fellowKeyUrlsafe} data.`)
-    dispatch(clearState())
-    dispatch(storeFellowKeyUrlsafe(fellowKeyUrlsafe))
     history.push('/resumake/generator')
   }
 }


### PR DESCRIPTION
1. Sync preview on load.
1. Persist fellow key for admins so that they don't lose the key on page reload. (They can't make requests to the website if they do.)
Note that I exclude fellow data from persistence since the form "clean" state is bound to it and we lose current form values when the form instantiates with those clean values on page reload.
1. Application will reset only when the new key differs from currently used one.
1. Sprinkle some toasts around so that request success/errors are indicated.
I did that in a very makeshift manner for now and it will definitely require a proper treatment later.