### PR TITLE
Some more tweaks

### DIFF
--- a/app/client/src/features/form/components/Form.js
+++ b/app/client/src/features/form/components/Form.js
@@ -21,7 +21,7 @@ import { ScrollToTop } from '../../../common/components'
 import { generateResume } from '../../preview/actions'
 import { setProgress } from '../../progress/actions'
 import { fetchFellowDataAndResetFormToIt } from '../../tdi/actions'
-import { mayResetFormToFellowData } from '../../tdi/selectors'
+import { mayResetFormToFellowData, formValuesFromFellowData } from '../../tdi/selectors'
 import { colors } from '../../../common/theme'
 import type { FormValues } from '../types'
 import type { State } from '../../../app/types'
@@ -137,7 +137,7 @@ function mapState(state: State) {
     formValues: state.form.resume.values,
     sections: state.progress.sections,
     progress: state.progress.progress,
-    initialValues: state.tdi.fellowData,
+    initialValues: formValuesFromFellowData(state),
     mayResetFormToFellowData: mayResetFormToFellowData(state)
   }
 }

--- a/app/client/src/features/progress/components/SideNav.js
+++ b/app/client/src/features/progress/components/SideNav.js
@@ -224,11 +224,16 @@ class SideNav extends Component<Props> {
             <RButton onClick={this.handleResetFormToSavedStateClick}>
               Load Data from Profile
             </RButton>
-            <RButton onClick={this.handleSaveFellowDataClick}>
-              Save Data to Profile
-            </RButton>
             {/* NOTE: disabled button avoids the tooltip without the wrapping spans. */}
             {/* See: https://github.com/wwayne/react-tooltip/issues/304 */}
+            <span
+              style={{ marginTop: '15px' }} // Aligning the tooltip
+              data-tip="Update preview to save data."
+              data-tip-disable={previewUpdated}>
+              <RButton style={{ marginTop: '0px' }} disabled={!previewUpdated} onClick={this.handleSaveFellowDataClick}>
+                Save Data to Profile
+              </RButton>
+            </span>
             <span
               style={{ marginTop: '15px' }} // Aligning the tooltip
               data-tip="Preview must be updated before publishing."

--- a/app/client/src/features/progress/reducer.js
+++ b/app/client/src/features/progress/reducer.js
@@ -5,7 +5,7 @@
 import type { ProgressState as State } from './types'
 import type { Action } from '../../app/types'
 
-const initialState = {
+export const initialState = {
   progress: 0,
   prev: 'templates',
   curr: 'templates',

--- a/app/client/src/features/tdi/actions.js
+++ b/app/client/src/features/tdi/actions.js
@@ -31,7 +31,7 @@ const TOAST_ERROR_OPTS = {
   position: toast.POSITION.TOP_RIGHT,
   hideProgressBar: true,
   closeButton: false,
-  autoClose: 3000
+  autoClose: 5000
 }
 
 

--- a/app/client/src/features/tdi/actions.js
+++ b/app/client/src/features/tdi/actions.js
@@ -4,13 +4,14 @@
 
 import { toast } from 'react-toastify'
 import { hasPrevSession } from '../../app/selectors'
-import { previewMatchesFellowData, hasNoFellowData } from './selectors'
+import { previewMatchesFellowData, hasNoFellowData, sectionOrderFromFellowData } from './selectors'
 import { isEqual } from 'lodash'
 import { reset } from 'redux-form'
 import type { Action, AsyncAction } from '../../app/types'
 import { FormValuesWithSectionOrder } from '../form/types'
 import { clearState } from '../../app/actions'
 import { generateResume } from '../../features/preview/actions'
+import { setSectionOrder } from '../../features/progress/actions'
 
 /**
  * NOTE: presentation layer (in this case - react toast) should not seep into
@@ -124,8 +125,10 @@ export function fetchFellowDataAndResetFormToIt(): AsyncAction {
       return
     }
     dispatch(reset('resume'))
-    const { fellowData } = getState().tdi
-    await dispatch(generateResume(fellowData))
+    const state = getState()
+    // NOTE: we can hard code arbitrary section since we ditched the progress bar anyways.
+    dispatch(setSectionOrder(sectionOrderFromFellowData(state, 'templates')))
+    await dispatch(generateResume(state.tdi.fellowData))
   }
 }
 

--- a/app/client/src/features/tdi/reducer.js
+++ b/app/client/src/features/tdi/reducer.js
@@ -8,13 +8,16 @@ import type { Action } from '../../app/types'
 
 // TODO: not typeizing yet
 
-export const initialState = {
-  fellowData: null, // NOTE: this is FormValuesWithSectionOrder!
-  fellowKeyUrlsafe: undefined
-}
-
 const initialFormValues = formInitialState.values
 const initialSections = progressInitialState.sections
+
+export const initialState = {
+  fellowData: {
+    ...initialFormValues,
+    sections: initialSections
+  }, // NOTE: this is FormValuesWithSectionOrder!
+  fellowKeyUrlsafe: undefined
+}
 
 function tdi(state = initialState, action) {
   switch (action.type) {
@@ -22,6 +25,7 @@ function tdi(state = initialState, action) {
       return {
         ...state,
         fellowData: {
+          // NOTE: initial form and section values protect us from empty {} server responses.
           ...initialFormValues,
           sections: initialSections,
           ...action.fellowData

--- a/app/client/src/features/tdi/reducer.js
+++ b/app/client/src/features/tdi/reducer.js
@@ -3,14 +3,18 @@
  */
 
 import { initialState as formInitialState } from '../form/reducer'
+import { initialState as progressInitialState } from '../progress/reducer'
 import type { Action } from '../../app/types'
 
 // TODO: not typeizing yet
 
 export const initialState = {
-  fellowData: null,
+  fellowData: null, // NOTE: this is FormValuesWithSectionOrder!
   fellowKeyUrlsafe: undefined
 }
+
+const initialFormValues = formInitialState.values
+const initialSections = progressInitialState.sections
 
 function tdi(state = initialState, action) {
   switch (action.type) {
@@ -18,7 +22,8 @@ function tdi(state = initialState, action) {
       return {
         ...state,
         fellowData: {
-          ...formInitialState.values,
+          ...initialFormValues,
+          sections: initialSections,
           ...action.fellowData
         }
       }

--- a/app/client/src/features/tdi/selectors.js
+++ b/app/client/src/features/tdi/selectors.js
@@ -4,6 +4,8 @@
 
 import { isEqual } from 'lodash'
 import type { State } from '../../app/types'
+import { FormValues } from '../form/types'
+import { Section } from '../../common/types'
 import { hasPrevSession } from '../../app/selectors'
 import { initialState } from './reducer'
 
@@ -16,7 +18,11 @@ export function previewMatchesFellowData(state: State): boolean {
 }
 
 export function previewMatchesFormData(state: State): boolean {
-  return isEqual(state.preview.data.json, state.form.resume.values)
+  const formValuesWithSectionOrder = {
+    ...state.form.resume.values,
+    sections: state.progress.sections
+  }
+  return isEqual(state.preview.data.json, formValuesWithSectionOrder)
 }
 
 export function mayResetFormToFellowData(state: State): boolean {
@@ -24,4 +30,16 @@ export function mayResetFormToFellowData(state: State): boolean {
   if (hasPrevSession(state)) return false
   if (!hasNoFellowData(state)) return false
   return true
+}
+
+export function formValuesFromFellowData(state: State): FormValues {
+  const {
+    sections,
+    ...fellowData
+  } = state.tdi.fellowData
+  return fellowData
+}
+
+export function sectionOrderFromFellowData(state: State): Array<Section> {
+  return state.tdi.fellowData.sections
 }


### PR DESCRIPTION
1. Loading an empty json initially would break the first automatic preview. Now it doesn't.
More specifically, since `sections` list is required in the template, we would get undefined access error on resumake server.
1. Disable save button just like publish.
1. Respect `FormDataWithSectionOrder`/`FormData` distinction.
Also, enable section reorder on data load.
(Otherwise admins and Fellows would _never_ agree on section order, unless one of them manually matches another's order.)