### PR TITLE
Handle auth errors

### DIFF
--- a/app/client/src/features/tdi/actions.js
+++ b/app/client/src/features/tdi/actions.js
@@ -57,6 +57,17 @@ function storeFellowKeyUrlsafe(fellowKeyUrlsafe: string): Action {
   }
 }
 
+function parseError(error) {
+  if (error.errors != undefined) {
+    try {
+      return error.errors.join('. ')
+    } catch (err) {
+      return error.errors
+    }
+  }
+  return error.message
+}
+
 function fetchFellowData(): AsyncAction {
   return async (dispatch, getState) => {
     const { fellowKeyUrlsafe } = getState().tdi
@@ -68,7 +79,7 @@ function fetchFellowData(): AsyncAction {
       const response = await fetch(fellowDataFetchUrl)
       const responseData = await response.json()
       if (!response.ok) {
-        toast(responseData.errors.join('. '), TOAST_ERROR_OPTS)
+        toast(parseError(responseData), TOAST_ERROR_OPTS)
         return false
       }
       const fellowData = responseData
@@ -101,7 +112,7 @@ export function saveFellowData(resumeData: FormValuesWithSectionOrder): AsyncAct
       const resp = await fetch(updateFellowDataUrl, request)
       if (!resp.ok) {
         const respObj = await resp.json()
-        toast(respObj.errors.join('. '), TOAST_ERROR_OPTS)
+        toast(parseError(respObj), TOAST_ERROR_OPTS)
         return false
       }
       dispatch(updateSavedFellowData(resumeData))
@@ -174,7 +185,7 @@ export function publishPDF(): AsyncAction {
         const response = await fetch(publishPDFUrl, request)
         if (!response.ok) {
           const responseData = await response.json()
-          toast(responseData.errors.join('. '), TOAST_ERROR_OPTS)
+          toast(parseError(responseData), TOAST_ERROR_OPTS)
           return
         }
         toast('Resume published to resume book.', TOAST_INFO_OPTS)

--- a/app/client/src/features/tdi/actions.js
+++ b/app/client/src/features/tdi/actions.js
@@ -107,7 +107,7 @@ function fetchFellowData(): AsyncAction {
       const fellowDataFetchBaseUrl = '/fellows/fetch_resume_json'
       const fellowDataFetchUrl = fellowKeyUrlsafe ? fellowDataFetchBaseUrl + '/' + fellowKeyUrlsafe : fellowDataFetchBaseUrl
       const response = await fetch(fellowDataFetchUrl)
-      if (handleAuthError(response)) {
+      if (await handleAuthError(response)) {
         return false
       }
       const responseData = await response.json()
@@ -143,7 +143,7 @@ export function saveFellowData(resumeData: FormValuesWithSectionOrder): AsyncAct
     try {
       const updateFellowDataUrl = fellowKeyUrlsafe ? '/fellows/update_resume_json/' + fellowKeyUrlsafe : '/fellows/update_resume_json'
       const resp = await fetch(updateFellowDataUrl, request)
-      if (handleAuthError(response)) {
+      if (await handleAuthError(response)) {
         return false
       }
       if (!resp.ok) {
@@ -219,7 +219,7 @@ export function publishPDF(): AsyncAction {
         const publishPDFBaseUrl = '/fellows/update_resume'
         const publishPDFUrl = fellowKeyUrlsafe ? publishPDFBaseUrl + '/' + fellowKeyUrlsafe : publishPDFBaseUrl
         const response = await fetch(publishPDFUrl, request)
-        if (handleAuthError(response)) {
+        if (await handleAuthError(response)) {
           return
         }
         if (!response.ok) {

--- a/app/client/src/features/tdi/components/AuthToast.js
+++ b/app/client/src/features/tdi/components/AuthToast.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const ToastDiv = styled.div`
+  &{
+    cursor: default;
+  }
+  & > :first-child {
+    margin-top: 0;
+  }
+  & > :last-child {
+    margin-bottom: 0;
+  }
+  & button {
+    border: thin solid white;
+    border-radius: 0.25em;
+    padding: 0.25em 2em;
+    background: inherit;
+    color: inherit;
+    cursor: pointer;
+  }
+  & button:hover {
+    text-decoration: underline;
+  }
+`
+
+const AuthToast = ({ loginURL, closeToast }) => {
+
+  const handleClick = () =>{
+    window.location.pathname = loginURL
+    closeToast()
+  }
+
+  return (
+    <ToastDiv>
+      <p>You are not logged in to the Data Incubator website.</p>
+      <button onClick={handleClick}>Go to Login Page</button>
+      <p>You will be returned to this page after logging in.  You may need to repeat your action.</p>
+    </ToastDiv>
+  )
+}
+
+export default AuthToast

--- a/app/client/src/features/tdi/components/AuthToast.js
+++ b/app/client/src/features/tdi/components/AuthToast.js
@@ -27,7 +27,7 @@ const ToastDiv = styled.div`
 const AuthToast = ({ loginURL, closeToast }) => {
 
   const handleClick = () =>{
-    window.location.pathname = loginURL
+    window.location = window.location.origin + loginURL
     closeToast()
   }
 


### PR DESCRIPTION
Two fixes:
1. Handle the two types of JSON errors we get back (see #6).
2. Do appropriate things for 401 and 403 errors.

Putting react components in the actions file is really sloppy, but it gets the job done.

Please go ahead and push fixes to this branch; I'd like to deploy it tomorrow if possible.