### PR TITLE
Deploy helper script

### DIFF
--- a/app/server/.dockerignore
+++ b/app/server/.dockerignore
@@ -1,0 +1,7 @@
+Dockerfile
+
+**/*.md
+**/node_modules/
+**/npm-debug.log
+**/dist
+**/lib

--- a/app/server/Dockerfile
+++ b/app/server/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:14.1.0-buster
+
+# Install tinytex, from https://tex.stackexchange.com/a/493882
+WORKDIR /var/local
+RUN wget -qO- "https://yihui.name/gh/tinytex/tools/install-unx.sh" | sh
+ENV PATH="${PATH}:/root/bin"
+RUN tlmgr install preprint enumitem ragged2e ms fancyhdr xcolor xifthen setspace ifmtarg unicode-math tocloft titlesec textpos hyphenat microtype moderncv epstopdf-pkg parskip tabu changepage babel-english sectsty isodate substr xltxtra realscripts koma-script
+ 
+COPY package*.json ./
+
+RUN npm ci
+
+COPY . .
+
+EXPOSE 3001
+
+ENTRYPOINT ["npm", "run"]
+CMD ["start"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -57,4 +57,4 @@ esac
 
 check_uncommitted
 
-echo $PROJECT
+gcloud app deploy --project $PROJECT app.yaml 

--- a/deploy.sh
+++ b/deploy.sh
@@ -64,4 +64,5 @@ check_uncommitted
 gcloud app deploy --project $PROJECT app.yaml 
 
 git tag -a $TAG -m "Deployed to $PROJECT with $TIMESTAMP timestamp. ($TAG)"
-echo "Don't forget to git push origin $TAG" 1>&2
+echo "Don't forget to: git push origin $TAG" 1>&2
+echo "Also, make sure GAE dispatch rules are deployed: gcloud app deploy --project $PROJECT dispatch.yaml" 1>&2

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,11 +8,20 @@ function usage_and_exit_1 {
 }
 
 function check_production_branch {
+    # 1) Check that we're on "newtemplate" branch.
     local master_branch='newtemplate'
     local git_branch=$(git symbolic-ref --short HEAD)
     if test $master_branch != $git_branch
     then
         echo 'You must be on "'$master_branch'" branch to deploy production!' 1>&2
+        exit 1
+    fi
+    # 2) Check that "newtemplate" and "origin/newtemplate" don't diverge.
+    local master_branch_hash="$(git rev-parse $master_branch)"
+    local master_branch_origin_hash="$(git rev-parse origin/$master_branch)"
+    if test $master_branch_hash != $master_branch_origin_hash
+    then
+        echo 'Branches "'$master_branch'" and "origin/'$master_branch'" diverge. Push your changes first!' 1>&2
         exit 1
     fi
 }

--- a/deploy.sh
+++ b/deploy.sh
@@ -41,14 +41,18 @@ then
     usage_and_exit_1
 fi
 
+TIMESTAMP=$(date +%s)
+
 case $1 in
     'production')
         echo -e '\033[0;31mDeploying to production!\033[0m'
         check_production_branch
         PROJECT='thedataincubator'
+        TAG="Prod$TIMESTAMP"
         ;;
     'staging')
         PROJECT='thedataincubator-staging'
+        TAG="Staging$TIMESTAMP"
         ;;
     *)
         usage_and_exit_1
@@ -58,3 +62,6 @@ esac
 check_uncommitted
 
 gcloud app deploy --project $PROJECT app.yaml 
+
+git tag -a $TAG -m "Deployed to $PROJECT with $TIMESTAMP timestamp. ($TAG)"
+echo "Don't forget to git push origin $TAG" 1>&2

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,6 +7,14 @@ function usage_and_exit_1 {
     exit 1
 }
 
+function check_uncommitted {
+    if test -n "$(git status --short)"
+    then
+        echo 'There are some uncommitted changes. Please commit or stash them first!' 1>&2
+        exit 1
+    fi
+}
+
 function check_production_branch {
     # 1) Check that we're on "newtemplate" branch.
     local master_branch='newtemplate'
@@ -16,7 +24,9 @@ function check_production_branch {
         echo 'You must be on "'$master_branch'" branch to deploy production!' 1>&2
         exit 1
     fi
-    # 2) Check that "newtemplate" and "origin/newtemplate" don't diverge.
+    # 2) Check that there are no uncommitted changes in the working tree.
+    check_uncommitted
+    # 3) Check that "newtemplate" and "origin/newtemplate" don't diverge.
     local master_branch_hash="$(git rev-parse $master_branch)"
     local master_branch_origin_hash="$(git rev-parse origin/$master_branch)"
     if test $master_branch_hash != $master_branch_origin_hash
@@ -45,10 +55,6 @@ case $1 in
         ;;
 esac
 
-if test -n "$(git status --short)"
-then
-    echo 'There are some uncommitted changes, please commit them first!' 1>&2
-    exit 1
-fi
+check_uncommitted
 
 echo $PROJECT

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,8 +2,16 @@
 
 set -e
 
-test $# -eq 1
-USAGE="Call $(basename "$0") with \"staging\" or \"production\""
+function usage_and_exit_1 {
+    echo "Call $(basename "$0") with one argument: \"staging\" or \"production\"" 1>&2
+    exit 1
+}
+
+if test $# -ne 1
+then
+    usage_and_exit_1
+fi
+
 case $1 in
     'production')
         PROJECT='thedataincubator'
@@ -12,8 +20,7 @@ case $1 in
         PROJECT='thedataincubator-staging'
         ;;
     *)
-        echo "$USAGE" 1>&2
-        exit 1
+        usage_and_exit_1
         ;;
 esac
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -61,8 +61,8 @@ esac
 
 check_uncommitted
 
-gcloud app deploy --project $PROJECT app.yaml 
+gcloud app deploy --project $PROJECT app.yaml
 
 git tag -a $TAG -m "Deployed to $PROJECT with $TIMESTAMP timestamp. ($TAG)"
-echo "Don't forget to: git push origin $TAG" 1>&2
-echo "Also, make sure GAE dispatch rules are deployed: gcloud app deploy --project $PROJECT dispatch.yaml" 1>&2
+echo -e "Don't forget to: \033[0;33mgit push origin $TAG\033[0m" 1>&2
+echo -e "Also, make sure GAE dispatch rules are deployed: \033[0;33mgcloud app deploy --project $PROJECT dispatch.yaml\033[0m" 1>&2

--- a/deploy.sh
+++ b/deploy.sh
@@ -17,4 +17,10 @@ case $1 in
         ;;
 esac
 
+if test -n "$(git status --short)"
+then
+    echo 'There are some uncommitted changes!' 1>&2
+    exit 1
+fi
+
 echo $PROJECT

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,20 @@
+# A wrapper script for "gcloud app deploy"
+
+set -e
+
+test $# -eq 1
+USAGE="Call $(basename "$0") with \"staging\" or \"production\""
+case $1 in
+    'production')
+        PROJECT='thedataincubator'
+        ;;
+    'staging')
+        PROJECT='thedataincubator-staging'
+        ;;
+    *)
+        echo "$USAGE" 1>&2
+        exit 1
+        ;;
+esac
+
+echo $PROJECT

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,6 +7,16 @@ function usage_and_exit_1 {
     exit 1
 }
 
+function check_production_branch {
+    local master_branch='newtemplate'
+    local git_branch=$(git symbolic-ref --short HEAD)
+    if test $master_branch != $git_branch
+    then
+        echo 'You must be on "'$master_branch'" branch to deploy production!' 1>&2
+        exit 1
+    fi
+}
+
 if test $# -ne 1
 then
     usage_and_exit_1
@@ -14,6 +24,8 @@ fi
 
 case $1 in
     'production')
+        echo -e '\033[0;31mDeploying to production!\033[0m'
+        check_production_branch
         PROJECT='thedataincubator'
         ;;
     'staging')
@@ -26,7 +38,7 @@ esac
 
 if test -n "$(git status --short)"
 then
-    echo 'There are some uncommitted changes!' 1>&2
+    echo 'There are some uncommitted changes, please commit them first!' 1>&2
     exit 1
 fi
 

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ To run the client, first install the dependencies with `npm run build:client`.  
 ```
 npm run start:client
 ```
-The client is automatically set up to connect to port 3001 for the server, so everything should just work.
+The client development server is set up to proxy api requests to port 3001 for the server, so everything should just work.
 
 ## Contributing
 Contributions are very welcome, and I am always happy to help out first-timers contributors with any questions you may have. You can check out the [contributing.md](./contributing.md) for an in-depth guide on how to get started on working on the app.


### PR DESCRIPTION
`deploy.sh` - should lower deployment mental efforts.

Note that the script is not thoroughly tested - we might need to edit some rough edges later.  (Obviously, this kind of operations-code is not really isolation-testable - time and usage will test it.)