### PR TITLE
Add mime types to nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -3,6 +3,8 @@
 events {}
 
 http {
+    include mime.types;
+
     server {
         listen 8080;
 


### PR DESCRIPTION
This ensures static files are served with the right types, so that
Firefox doesn't complain.