### PR TITLE
Change definition of fillorsplit

### DIFF
--- a/app/server/src/generator/templates/tditemplate/inputs/config/minimal-resume.sty
+++ b/app/server/src/generator/templates/tditemplate/inputs/config/minimal-resume.sty
@@ -45,8 +45,8 @@
   {\itemize[nolistsep,topsep=\sizefive,itemsep=\sizefive,labelsep=0pt,leftmargin=0pt,label={}]}
   {\enditemize}
 
-% Trickery from https://tex.stackexchange.com/a/114077
-\newcommand{\fillorsplit}{\hspace{\fill}\mbox{}\linebreak[0]\hspace*{\fill}}
+% \hspace* keeps space at end of lines from being gobbled up.
+\newcommand{\fillorsplit}{\hspace*{\fill}\discretionary{}{}{}\hspace*{\fill}}
 
 \newcommand{\chap}[2]{
   \vspace{\sizethree}

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,6 +3,8 @@
 events {}
 
 http {
+    include mime.types;
+
     server {
         listen 8080;
 


### PR DESCRIPTION
This uses \discretionary, rather than \linebreak[0], to keep LaTeX
from feeling as strongly about adding a line break.  The result is
that multi-line titles can still have the following element on the
last line, if there's space.